### PR TITLE
Fix Powerline glyphs

### DIFF
--- a/sources/VictorMono-Italic.glyphs
+++ b/sources/VictorMono-Italic.glyphs
@@ -101158,7 +101158,7 @@ unicode = E0A2;
 {
 color = 4;
 glyphname = uniE0B0;
-lastChange = "2022-05-13 07:53:31 +0000";
+lastChange = "2023-07-12 10:02:20 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -101166,9 +101166,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 385 LINE",
+"600 425 LINE",
 "-1 1110 LINE",
-"-1 -340 LINE"
+"-1 -260 LINE"
 );
 }
 );
@@ -101180,9 +101180,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 386 LINE",
+"600 425 LINE",
 "-1 1110 LINE",
-"-1 -340 LINE"
+"-1 -260 LINE"
 );
 }
 );
@@ -101195,7 +101195,7 @@ unicode = E0B0;
 {
 color = 4;
 glyphname = uniE0B1;
-lastChange = "2022-05-13 07:53:31 +0000";
+lastChange = "2023-07-12 10:03:47 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -101203,12 +101203,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 385 LINE",
+"600 425 LINE",
 "51 1110 LINE",
 "0 1061 LINE",
-"501 385 LINE",
-"0 -291 LINE",
-"51 -340 LINE"
+"501 425 LINE",
+"0 -211 LINE",
+"51 -260 LINE"
 );
 }
 );
@@ -101220,12 +101220,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 385 LINE",
+"600 425 LINE",
 "51 1110 LINE",
 "0 1061 LINE",
-"501 385 LINE",
-"0 -291 LINE",
-"51 -340 LINE"
+"501 425 LINE",
+"0 -211 LINE",
+"51 -260 LINE"
 );
 }
 );
@@ -101238,7 +101238,7 @@ unicode = E0B1;
 {
 color = 4;
 glyphname = uniE0B2;
-lastChange = "2022-05-13 07:53:31 +0000";
+lastChange = "2023-07-12 10:05:00 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -101247,8 +101247,8 @@ paths = (
 closed = 1;
 nodes = (
 "601 1110 LINE",
-"0 385 LINE",
-"601 -340 LINE"
+"0 425 LINE",
+"601 -260 LINE"
 );
 }
 );
@@ -101261,8 +101261,8 @@ paths = (
 closed = 1;
 nodes = (
 "601 1110 LINE",
-"0 385 LINE",
-"601 -340 LINE"
+"0 425 LINE",
+"601 -260 LINE"
 );
 }
 );
@@ -101275,7 +101275,7 @@ unicode = E0B2;
 {
 color = 4;
 glyphname = uniE0B3;
-lastChange = "2022-05-13 07:53:31 +0000";
+lastChange = "2023-07-12 10:06:39 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -101283,12 +101283,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 -291 LINE",
-"99 385 LINE",
+"600 -211 LINE",
+"99 425 LINE",
 "600 1061 LINE",
 "549 1110 LINE",
-"0 385 LINE",
-"549 -340 LINE"
+"0 425 LINE",
+"549 -260 LINE"
 );
 }
 );
@@ -101300,12 +101300,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 -291 LINE",
-"99 385 LINE",
+"600 -211 LINE",
+"99 425 LINE",
 "600 1061 LINE",
 "549 1110 LINE",
-"0 385 LINE",
-"549 -340 LINE"
+"0 425 LINE",
+"549 -260 LINE"
 );
 }
 );

--- a/sources/VictorMono.glyphs
+++ b/sources/VictorMono.glyphs
@@ -88270,7 +88270,7 @@ unicode = E0A2;
 {
 color = 4;
 glyphname = uniE0B0;
-lastChange = "2021-10-18 17:22:14 +0000";
+lastChange = "2023-07-12 09:53:36 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -88278,9 +88278,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 385 LINE",
+"600 425 LINE",
 "-1 1110 LINE",
-"-1 -340 LINE"
+"-1 -260 LINE"
 );
 }
 );
@@ -88292,9 +88292,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 386 LINE",
+"600 425 LINE",
 "-1 1110 LINE",
-"-1 -340 LINE"
+"-1 -260 LINE"
 );
 }
 );
@@ -88307,7 +88307,7 @@ unicode = E0B0;
 {
 color = 4;
 glyphname = uniE0B1;
-lastChange = "2021-10-18 17:22:14 +0000";
+lastChange = "2023-07-12 09:56:27 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -88315,12 +88315,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 385 LINE",
+"600 425 LINE",
 "51 1110 LINE",
 "0 1061 LINE",
-"501 385 LINE",
-"0 -291 LINE",
-"51 -340 LINE"
+"501 425 LINE",
+"0 -211 LINE",
+"51 -260 LINE"
 );
 }
 );
@@ -88332,12 +88332,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 385 LINE",
+"600 425 LINE",
 "51 1110 LINE",
 "0 1061 LINE",
-"501 385 LINE",
-"0 -291 LINE",
-"51 -340 LINE"
+"501 425 LINE",
+"0 -211 LINE",
+"51 -260 LINE"
 );
 }
 );
@@ -88350,7 +88350,7 @@ unicode = E0B1;
 {
 color = 4;
 glyphname = uniE0B2;
-lastChange = "2021-10-18 17:22:14 +0000";
+lastChange = "2023-07-12 09:57:23 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -88359,8 +88359,8 @@ paths = (
 closed = 1;
 nodes = (
 "601 1110 LINE",
-"0 385 LINE",
-"601 -340 LINE"
+"0 425 LINE",
+"601 -260 LINE"
 );
 }
 );
@@ -88373,8 +88373,8 @@ paths = (
 closed = 1;
 nodes = (
 "601 1110 LINE",
-"0 385 LINE",
-"601 -340 LINE"
+"0 425 LINE",
+"601 -260 LINE"
 );
 }
 );
@@ -88387,7 +88387,7 @@ unicode = E0B2;
 {
 color = 4;
 glyphname = uniE0B3;
-lastChange = "2021-10-18 17:22:14 +0000";
+lastChange = "2023-07-12 09:59:08 +0000";
 layers = (
 {
 layerId = "7C079D0C-96CD-4BD8-8800-0621C7635A78";
@@ -88395,12 +88395,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 -291 LINE",
-"99 385 LINE",
+"600 -211 LINE",
+"99 425 LINE",
 "600 1061 LINE",
 "549 1110 LINE",
-"0 385 LINE",
-"549 -340 LINE"
+"0 425 LINE",
+"549 -260 LINE"
 );
 }
 );
@@ -88412,12 +88412,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"600 -291 LINE",
-"99 385 LINE",
+"600 -211 LINE",
+"99 425 LINE",
 "600 1061 LINE",
 "549 1110 LINE",
-"0 385 LINE",
-"549 -340 LINE"
+"0 425 LINE",
+"549 -260 LINE"
 );
 }
 );


### PR DESCRIPTION
**[why]**  
The Powerline glyphs protrude noticeable down into the next line.

The reason is that the lowest point of that glyphs is at -340 while the descenders is only set to -250. The ascenders and descenders is used by terminals to determine baseline to baseline distance (together with the gap, sometimes, which is zero in this font).

**[how]**  
Move the bottom and middle points of the Powerline glyphs `E0B0` `E0B1` `E0B2` `E0B3`

The top point has an overshoot of 10 (line top is at 1100, top point coordinate is at 1110), so kept the same amount of overshoot for the bottom point: line bottom is at -250, bottom point should be a -260.

Bottom:
```
-340 -> -260
-291 -> -211    (same distance up)
```

Middle:
```
 385 ->  425    (half the distance to keep centered)
```

**[note]**  
Did the changes in Glyph3 but commited only the basic changes while keeping the version number in the glyphs file.

Fixes: https://github.com/rubjo/victor-mono/issues/155